### PR TITLE
Add a basic printf implementation

### DIFF
--- a/base/Fmt/sprintf.kind
+++ b/base/Fmt/sprintf.kind
@@ -1,0 +1,152 @@
+// Specifier represents an element of a parsed format string.
+type Fmt.Specifier {
+  // An integer format specifier - %d.
+  integer,
+
+  // A string format specifier - %s.
+  string,
+
+  // A character in the format string.
+  char(c: Char)
+}
+
+Fmt.Specifier.show(s: Fmt.Specifier): String
+  case s {
+    integer: "%d",
+    string: "%s",
+    char: String.append("", s.c),
+  }
+
+Fmt.Parser.string: Parser(Fmt.Specifier)
+  do Parser {
+    Parser.text("%s")
+    return Fmt.Specifier.string;
+  }
+
+Fmt.Parser.integer: Parser(Fmt.Specifier)
+  do Parser {
+    Parser.text("%d")
+    return Fmt.Specifier.integer;
+  }
+
+Fmt.Parser.percent: Parser(Fmt.Specifier)
+  do Parser {
+    Parser.text("%%")
+    return Fmt.Specifier.char('%');
+  }
+
+Fmt.Parser.char: Parser(Fmt.Specifier)
+  do Parser {
+    var c = Parser.one
+    return Fmt.Specifier.char(c);
+  }
+
+Fmt.Parser.parser(xs: List(Fmt.Specifier)): Parser(List(Fmt.Specifier))
+  do Parser {
+    var stop = Parser.is_eof;
+    if stop then do Parser {
+      return xs;
+    } else do Parser {
+      var x = Parser.first_of!([
+        Fmt.Parser.string,
+        Fmt.Parser.integer,
+        Fmt.Parser.percent,
+        Fmt.Parser.char
+      ])
+      Fmt.Parser.parser(List.append!(xs, x))
+    }
+  }
+
+Fmt.Parser.parse(input: String): List(Fmt.Specifier)
+  case Fmt.Parser.parser([], 0, input) as parsed {
+    error: []
+    value: parsed.val
+  }
+
+// arguments returns the type of arguments that sprintf expects based on the
+// format string, for example, "%d is %d" would evaluate to
+// Nat -> Nat -> String - i.e. the formatter that takes two Nats and returns
+// the formatted String.
+Fmt.arguments(format: List(Fmt.Specifier)): Type
+  case format {
+    nil: String // the final result is a String
+    cons: case format.head {
+      integer: Nat -> Fmt.arguments(format.tail)
+      string: String -> Fmt.arguments(format.tail)
+      char: Fmt.arguments(format.tail)
+    }
+  }
+
+Fmt.sprintf.go(str: String, xs: List(Fmt.Specifier)): Fmt.arguments(xs)
+  case xs {
+    nil: str
+    cons: case xs.head {
+      integer: (i) Fmt.sprintf.go(str | Nat.show(i), xs.tail)
+      string: (s) Fmt.sprintf.go(str | s, xs.tail)
+      char: Fmt.sprintf.go(String.append(str, xs.head.c), xs.tail)
+    }!
+  }!
+
+// sprintf takes a format string and substitutes any format specifiers that
+// appear in the string with user supplied arguments. The following format
+// specifiers are currently supported:
+//   %d - a Nat 
+//   %s - a String
+//   %% - a percent character
+//
+// Example usage:
+//   Fmt.sprintf("%s %d!", "hello", 5) == "hello 5!"
+//
+Fmt.sprintf(format: String): Fmt.arguments(Fmt.Parser.parse(format))
+  Fmt.sprintf.go("", Fmt.Parser.parse(format))
+
+Fmt.sprintf.example.hello: String
+  Fmt.sprintf("%s world", "hello")
+  
+Fmt.sprintf.example.number: String
+  Fmt.sprintf("%d", 123)
+
+Fmt.sprintf.example.char: String
+  Fmt.sprintf("a")
+
+Fmt.sprintf.example.empty: String
+  Fmt.sprintf(String.nil)
+
+Fmt.sprintf.example.percent: String
+  Fmt.sprintf("%%")
+
+Fmt.sprintf.test.string1a: Fmt.arguments(List.nil!) == String
+  refl
+
+Fmt.sprintf.test.string1b: Fmt.arguments([Fmt.Specifier.char('a')]) == String
+  refl
+
+Fmt.sprintf.test.string1c: Fmt.arguments([Fmt.Specifier.char('a'), Fmt.Specifier.integer]) == Nat -> String
+  refl
+
+Fmt.sprintf.test.string2a: Fmt.arguments(Fmt.Parser.parse("a")) == String
+  refl
+
+Fmt.sprintf.test.string2: Fmt.sprintf("a") == "a"
+  refl
+
+Fmt.sprintf.test.string3a: Fmt.arguments(Fmt.Parser.parse("%d")) == Nat -> String
+  refl
+
+Fmt.sprintf.test.string3: Fmt.sprintf("%d")(1) == "1"
+  refl
+
+Fmt.sprintf.test.string4a: Fmt.arguments(Fmt.Parser.parse("%s world")) == String -> String
+  refl
+
+Fmt.sprintf.test.string4: Fmt.sprintf("%s world", "hello") == "hello world"
+  refl
+
+Fmt.sprintf.test.string5a: Fmt.arguments(Fmt.Parser.parse("%%")) == String
+  refl
+
+Fmt.sprintf.test.string5: Fmt.sprintf("%%") == "%"
+  refl
+
+Fmt.sprintf.test.string_and_number: Fmt.sprintf("%s %d!", "hello", 5) == "hello 5!"
+  refl


### PR DESCRIPTION
This PR introduces a basic C-style `sprintf` function that takes a format string like "string %s int %d" and allows users to pass values that will be substituted. Of course, the aim here is for dependent types so users of `sprintf` can only pass arguments of the correct type.

WIP: Note that this implementation doesn't currently type check, the `Fmt.sprintf.example.` functions are failing.
